### PR TITLE
Fix 1 parameter error

### DIFF
--- a/src/curve_fit.jl
+++ b/src/curve_fit.jl
@@ -30,7 +30,11 @@ function lmfit(f::Function, p0; kwargs...)
 	p = results.minimum
 	resid = f(p)
 	dof = length(resid) - length(p)
-	return LsqFitResult(dof, p, f(p), g(p))
+	if typeof(p) <: AbstractVector
+		return LsqFitResult(dof, p, f(p), g(p))
+	else
+		return LsqFitResult(dof, [p], f(p), g([p]))
+	end
 end
 
 function curve_fit(model::Function, xpts, ydata, p0; kwargs...)


### PR DESCRIPTION
in the current master for Optim.jl, `p` is a number and not a vector when there is only 1 parameter. This causes an error any time one tries to use lmfit with 1 parameter. This fixes the error in the most straight-forward way.
