### PR TITLE
Revert changes that don't improve performance

### DIFF
--- a/src/levenberg_marquardt.jl
+++ b/src/levenberg_marquardt.jl
@@ -78,7 +78,7 @@ function levenberg_marquardt{T}(f::Function, g::Function, initial_x::AbstractVec
         # we want to solve:
         #    argmin 0.5*||J(x)*delta_x + f(x)||^2 + lambda*||diagm(J'*J)*delta_x||^2
         # Solving for the minimum gives:
-        #    (J'*J + lambda*diagm(DtD)) * delta_x == -J^T * f(x), where DtD = sumabs2(J,1)
+        #    (J'*J + lambda*diagm(DtD)) * delta_x == -J' * f(x), where DtD = sumabs2(J,1)
         # Where we have used the equivalence: diagm(J'*J) = diagm(sumabs2(J,1))
         # It is additionally useful to bound the elements of DtD below to help
         # prevent "parameter evaporation".
@@ -114,13 +114,7 @@ function levenberg_marquardt{T}(f::Function, g::Function, initial_x::AbstractVec
         A_mul_B!(m_buffer, J, delta_x)
         LinAlg.axpy!(1, fcur, m_buffer)
         predicted_residual = sumabs2(m_buffer)
-        # check for numerical problems in solving for delta_x by ensuring that the predicted residual is smaller
-        # than the current residual
-        if predicted_residual > residual + 2max(eps(predicted_residual),eps(residual))
-            warn("""Problem solving for delta_x: predicted residual increase.
-                             $predicted_residual (predicted_residual) >
-                             $residual (residual) + $(eps(predicted_residual)) (eps)""")
-        end
+
         # try the step and compute its quality
         @simd for i in 1:n
             @inbounds n_buffer[i] = x[i] + delta_x[i]


### PR DESCRIPTION
Optim.jl PR #157 included a number of changes for potential performance improvement to our implementation of Levenberg-Marquardt. However, these changes came at a significant cost to code readability. Consequently, I decided to measure the efficacy of the changes. With the exception of the revised calculation of delta_x, none of the changes had a measurable impact. The change to the
delta_x computation improves performance by 2-5%, which I am not sure is worth it.

My benchmarking script is the following:
```julia
using BenchmarkTools
using LsqFit

# fitting noisy data to an exponential model
model(x, p) = p[1]*exp(-x.*p[2])

srand(12345)
pts = 10
xdata = linspace(0,10,pts)
ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))

println("$pts sample fitting")
b1 = @benchmark curve_fit(model, xdata, ydata, [0.5, 0.5])
println(b1)

pts = 100
xdata = linspace(0,10,pts)
ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
println("$pts sample fitting")
b2 = @benchmark curve_fit(model, xdata, ydata, [0.5, 0.5])
println(b2)

pts = 1000
xdata = linspace(0,10,pts)
ydata = model(xdata, [1.0, 2.0]) + 0.01*randn(length(xdata))
println("$pts sample fitting")
b3 = @benchmark curve_fit(model, xdata, ydata, [0.5, 0.5])
println(b3)
```

On current master, I see:

| samples | min     | median  | memory |
|---------|--------|---------|---------|
| 10     | 45 us   | 47.6 us | 45 kb  |
| 100   | 242 us | 247 us | 207 kb |
| 1000 | 1.85 ms | 1.94 ms | 1.74 Mb |

Whereas after these changes we have:

| samples | min     | median  | memory |
|---------|--------|---------|---------|
| 10     | 46.1 us   | 48.6 us | 50 kb  |
| 100   | 224 us | 230 us | 221 kb |
| 1000 | 1.84 ms | 1.95 ms | 1.86 Mb |

And if I additionally go back to the easier to read calculation of `delta_x` then I get:

| samples | min     | median  | memory |
|---------|--------|---------|---------|
| 10     | 50.9 us   | 55.2 us | 58.6 kb  |
| 100   | 238 us | 242 us | 255 kb |
| 1000 | 1.89 ms | 2.01 ms | 2.11 Mb |

